### PR TITLE
Fix #2: Abstract IMAP configuration to access mailboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ const { Rtteo } = require('rtteo')
 // Type: alarm, Company: XYZ Corp.
 const rtteo = new Rtteo({
   // You can define whatever mail provider you like editing the config/default.json file
-  provider: 'gmail'
+  provider: 'gmail',
   email: 'john.doe@gmail.com',
   password: 'password',
   subjects: {

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ const { Rtteo } = require('rtteo')
 // An email with a subject like 'Alarm from: ets XYZ Corp' will result in:
 // Type: alarm, Company: XYZ Corp.
 const rtteo = new Rtteo({
-  email: 'john.doe@example.com',
+  // You can define whatever mail provider you like editing the config/default.json file
+  provider: 'gmail'
+  email: 'john.doe@gmail.com',
   password: 'password',
   subjects: {
     alarm: new RegExp('Alarm from: ets (.*)'),

--- a/config/default.json
+++ b/config/default.json
@@ -1,0 +1,14 @@
+{
+ "mailServers": {
+     "gmail": {
+        "host": "imap.gmail.com",
+        "port": "993",
+        "tls": true
+     },
+     "outlook": {
+        "host": "imap-mail.outlook.com",
+        "port": "993",
+        "tls": true
+     }
+    }     
+}

--- a/examples/basic_example.js
+++ b/examples/basic_example.js
@@ -1,7 +1,8 @@
 const { Rtteo } = require('./../index')
 
 const rtteo = new Rtteo({
-  email: 'john.doe@example.com',
+  provider: 'gmail',
+  email: 'john.doe@gmail.com',
   password: 'password',
   subjects: {
     alarm: new RegExp('Alarm from: ets (.*)'),

--- a/examples/config/default.json
+++ b/examples/config/default.json
@@ -1,0 +1,14 @@
+{
+ "mailServers": {
+     "gmail": {
+        "host": "imap.gmail.com",
+        "port": "993",
+        "tls": true
+     },
+     "outlook": {
+        "host": "imap-mail.outlook.com",
+        "port": "993",
+        "tls": true
+     }
+    }     
+}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "jest": "^23.6.0"
   },
   "dependencies": {
+    "config": "^2.0.1",
     "imap": "^0.8.19",
     "mailparser": "^2.3.4",
     "nodemailer": "^4.6.8",

--- a/src/rtteo.js
+++ b/src/rtteo.js
@@ -1,6 +1,10 @@
 const imap = require('imap')
 const mailParser = require('mailparser').simpleParser
 
+/* Load mail servers generic config */
+const config = require('config')
+const mailServers = config.get('mailServers')
+
 class Rtteo {
   constructor (config, callback, mailer = null, parser = null) {
     this.config = config
@@ -18,9 +22,9 @@ class Rtteo {
     this.inbox = this.mailer({
       user: this.config.email,
       password: this.config.password,
-      host: 'imap.gmail.com',
-      port: 993,
-      tls: true
+      host: mailServers.get(this.config.provider + '.host'),
+      port: mailServers.get(this.config.provider + '.port'),
+      tls: mailServers.get(this.config.provider + '.tls')
     })
 
     this.inbox.once('ready', this._openInbox.bind(this))


### PR DESCRIPTION
"**provider**" parameter is now required.

Users can use the already defined "gmail" or "outlook" definitions.
It is also possible to add any mail server editing accordingly **config/default.json**.